### PR TITLE
Fix Socket issue with checksum generation

### DIFF
--- a/src/Connection/Fsockopen/Fsockopen.php
+++ b/src/Connection/Fsockopen/Fsockopen.php
@@ -24,9 +24,9 @@ class Fsockopen extends AbstractConnection
     public function ping($host)
     {
         $this->startTimer();
-        $fp = @fsockopen($host, $this->config->getPort(), $errNo, $errStr, 10);
+        $fp = @fsockopen($host, $this->config->getPort(), $errNo, $errStr, 5);
 
-        if (!$fp) {
+        if ($fp === false) {
             $this->latency = false;
             $this->errorMessage = [
                 'errNo'  => $errNo,

--- a/src/Connection/Socket/Packet.php
+++ b/src/Connection/Socket/Packet.php
@@ -38,7 +38,7 @@ class Packet
      * part of packet
      * Length: 16 bits
      */
-    protected $checksum = "\x00\x00";
+    protected $checksum;
 
     /**
      * Payload data sending with a ping.
@@ -71,6 +71,8 @@ class Packet
      */
     public function generateChecksum()
     {
+        $this->checksum = "\x00\x00";
+
         $data = $this->getPacketString();
         if (strlen($data) % 2) {
             $data .= "\x00";

--- a/src/Connection/Socket/Socket.php
+++ b/src/Connection/Socket/Socket.php
@@ -13,6 +13,11 @@ use luklew\MyLittlePing\Config;
 class Socket extends AbstractConnection
 {
     /**
+     * Connection timeout in seconds
+     */
+    const TIMEOUT = 5;
+
+    /**
      * Data packet
      *
      * @var Packet
@@ -48,8 +53,7 @@ class Socket extends AbstractConnection
      */
     public function ping($host)
     {
-        // TODO: IF added temporary due to issue that disallows generate checksum twice
-        if ($this->package === null) {
+        if ($this->packet->getPayload() !== $this->config->getPayload()) {
             $this->package = $this->packet
                 ->setPayload($this->config->getPayload())
                 ->generateChecksum()
@@ -61,7 +65,7 @@ class Socket extends AbstractConnection
         try {
             if (@$socket = socket_create(AF_INET, SOCK_RAW, 1)) {
                 socket_set_option($socket, SOL_SOCKET, SO_RCVTIMEO, array(
-                    'sec' => 10,
+                    'sec' => self::TIMEOUT,
                     'usec' => 0,
                 ));
                 @socket_connect($socket, $host, $this->config->getPort());

--- a/src/Ping.php
+++ b/src/Ping.php
@@ -88,7 +88,7 @@ class Ping
      *
      * @return Ping
      */
-    public static function createWithConnection($connectionType)
+    static public function createWithConnection($connectionType)
     {
         $config = new Config();
         $connection = ConnectionFactory::create($connectionType, $config);


### PR DESCRIPTION
Using socket connection it was possible to send exactly the same packet as
first time only. This is fix for checksum generation which makes it possible to
as resend previous package as create a new one if parameters were changed.
Also connection timeout was changed from 10 to 5 seconds.
